### PR TITLE
replaced links to point at cli.cloudfoundry.org pages

### DIFF
--- a/use-cli-plugins.html.md.erb
+++ b/use-cli-plugins.html.md.erb
@@ -63,7 +63,7 @@ https:/<span>/</span>plugins.cloudfoundry.org/list added as 'CF-Community'
 
 ## <a id="listing-plugin-repo"></a>Listing Available Plugin Repos ##
 
-Run `cf list-plugin-repos` to view your available plugin repos.
+Run [cf list-plugin-repos](http://cli.cloudfoundry.org/en-US/cf/list-plugin-repos.html) to view your available plugin repos.
 
 Example:
 <pre class="terminal">
@@ -75,7 +75,7 @@ CF-Community   https:/<span>/</span>plugins.cloudfoundry.org
 
 ## <a id="listing-plugin-repo"></a>Listing All Plugins by Repo ##
 
-Run `cf repo-plugins` to show all plugins from all available repos.
+Run [cf repo-plugins](http://cli.cloudfoundry.org/en-US/cf/repo-plugins.html) to show all plugins from all available repos.
 
 ## <a id="troubleshoot"></a>Troubleshooting ##
 


### PR DESCRIPTION
as discussed with @kimahoff 