### PR TITLE
Replace the tab with 4 spaces

### DIFF
--- a/use-cli-plugins.html.md.erb
+++ b/use-cli-plugins.html.md.erb
@@ -31,10 +31,10 @@ download source code, you must compile the code to create a binary.</p>
 1. Run `cf install-plugin BINARY_FILENAME` to install a plugin. Replace `BINARY_FILENAME` with the path to and name of your binary file.
 
     <p class="note"><strong>Note</strong>:
-	You cannot install a plugin that has the same name or that uses the             same command as an existing plugin. You must first uninstall the                existing plugin.
+    You cannot install a plugin that has the same name or that uses the             same command as an existing plugin. You must first uninstall the                existing plugin.
 </p>
     <p class="note"><strong>Note</strong>:
-	The cf CLI prohibits you from implementing any plugin that uses a               native cf CLI command name or alias. For example, if you attempt to             install a third-party plugin that includes the command <code>cf                 push</code>, the cf CLI halts the installation.</p>
+    The cf CLI prohibits you from implementing any plugin that uses a               native cf CLI command name or alias. For example, if you attempt to             install a third-party plugin that includes the command <code>cf                 push</code>, the cf CLI halts the installation.</p>
 
 ## <a id="plugin-run-cmd"></a>Running a Plugin Command ##
 


### PR DESCRIPTION
Spaces, it is aligned to view code with any editor, including the web
page view (such as in the GitHub code). When use tabs, the view on the
page is chaos, and it is terrible to mix tabs and spaces.