### PR TITLE
create Linux installation instructions

### DIFF
--- a/install-go-cli.html.md.erb
+++ b/install-go-cli.html.md.erb
@@ -19,12 +19,21 @@ To install the cf CLI on Windows:
 1. To verify your installation, open a terminal window and type `cf`.
 If your installation was successful, the cf CLI help listing appears.
 
-### <a id="nixlike"></a>Mac OS X and Linux Installation###
+### <a id="mac"></a>Mac OS X Installation###
 
 1. Open the `.pkg` file.
 1. In the installer wizard, click **Continue**.
 1. Select an install destination and click **Continue**.
 1. When prompted, click **Install**.
+1. To verify your installation, open a terminal window and type `cf`.
+If your installation was successful, the cf CLI help listing appears.
+
+### <a id="linux"></a>Linux Installation###
+
+1. Download the appropriate package from the [CLI releases page](https://github.com/cloudfoundry/cli/releases).
+1. Install using your system's package manager. Note these commands may require `sudo`.
+    * Debian/Ubuntu: `dpkg -i path/to/cf-cli-*.deb && apt-get install -f`
+    * Red Hat: `rpm -i path/to/cf-cli-*.rpm`
 1. To verify your installation, open a terminal window and type `cf`.
 If your installation was successful, the cf CLI help listing appears.
 


### PR DESCRIPTION
The previously grouped instructions were only for Mac.

/cc @konklone