### PR TITLE
add description for restart and restage

### DIFF
--- a/cf-help.html.md.erb
+++ b/cf-help.html.md.erb
@@ -118,11 +118,11 @@ title: Cloud Foundry CLI Reference Guide
     </tr>
     <tr>
       <td><a href='http://cli.cloudfoundry.org/en-US/cf/restart.html' target='_blank'>restart</a></td>
-      <td>Restart an app</td>
+      <td>Stop and restart the app within the existing droplet</td>
     </tr>
     <tr>
       <td><a href='http://cli.cloudfoundry.org/en-US/cf/restage.html' target='_blank'>restage</a></td>
-      <td>Restage an app</td>
+      <td>Run the application bits through the staging process to create and start a new droplet</td>
     </tr>
     <tr>
       <td><a href='http://cli.cloudfoundry.org/en-US/cf/restart-app-instance.html' target='_blank'>restart-app-instance</a></td>


### PR DESCRIPTION
add descriptions for the `cf restart` and `cf restage` commands since the difference between the two is not clear to new users