### PR TITLE
Deep-linked instructions now more self-contained

### DIFF
--- a/install-go-cli.html.md.erb
+++ b/install-go-cli.html.md.erb
@@ -42,12 +42,13 @@ For Enterprise Linux and Fedora systems (RHEL6/CentOS6 and up), perform the foll
 
 ## <a id="installer"></a>Use an Installer ##
 
-Download the installer for Mac OS X, Windows, or Linux from the cf CLI GitHub [repository](https://github.com/cloudfoundry/cli#installers-and-compressed-binaries) and follow the instructions for your operating system below.
+Follow the instructions for your operating system below.
 
 ### <a id="windows"></a>Windows Installation###
 
 To use the cf CLI installer for Windows, perform the following steps:
 
+1. Download [the Windows installer](https://cli.run.pivotal.io/stable?release=windows64&source=github)
 1. Unpack the zip file.
 1. Double click the `cf CLI` executable.
 1. When prompted, click **Install**, then **Close**.
@@ -58,6 +59,7 @@ If your installation was successful, the cf CLI help listing appears.
 
 To use the cf CLI installer for Mac OS X, perform the following steps:
 
+1. Download [the OS X installer](https://cli.run.pivotal.io/stable?release=macosx64&source=github)
 1. Open the `.pkg` file.
 1. In the installer wizard, click **Continue**.
 1. Select an install destination and click **Continue**.
@@ -69,6 +71,7 @@ If your installation was successful, the cf CLI help listing appears.
 
 To use the cf CLI installer for Linux, perform the following steps:
 
+1. Download the Linux installer for your [Debian/Ubuntu](https://cli.run.pivotal.io/stable?release=debian64&source=github) or [Red Hat](https://cli.run.pivotal.io/stable?release=redhat64&source=github) system
 1. Install using your system's package manager. Note these commands may require `sudo`.
     * For Debian/Ubuntu, run the following command: 
     <pre class="terminal">$ dpkg -i path/to/cf-cli-*.deb && apt-get install -f</pre>


### PR DESCRIPTION
The simplest thing to do from other places is to link directly to the instructions for a given OS, eg https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#windows

However when you do this, the user has to scroll up to see the link to download an installer, then they have to click through, then they have to know which version to download on a confusing page... even though the links on that page are not version-dependent.

This change puts the OS-specific download link right in the OS-specific instructions, making it very obvious what to do without sending the user through other pages and contexts.