### PR TITLE
removed note on super old minimum cf CLI version for plugins

### DIFF
--- a/use-cli-plugins.html.md.erb
+++ b/use-cli-plugins.html.md.erb
@@ -11,10 +11,6 @@ The cf CLI identifies a plugin by its binary filename, its developer-defined plu
 
 <p class="note"><strong>Note</strong>: The cf CLI uses case-sensitive plugin names and commands, but not case-sensitive binary filenames.</p>
 
-## <a id="prereqs"></a>Prerequisites ##
-
-Using plugins requires cf CLI v.6.7 or higher. Refer to the [Installing the cf CLI](./install-go-cli.html) topic for information about downloading, installing, and uninstalling the cf CLI.
-
 ## <a id="plugin-directory"></a>Changing the Plugin Directory ##
 
 By default, the cf CLI stores plugins in `$HOME/.cf/plugins` on your workstation. To change the root directory of this path from `$HOME`, set the `CF_PLUGIN_HOME` environment variable. The cf CLI appends `.cf/plugins` to the `CF_PLUGIN_HOME` path that you specify and stores plugins in that location.


### PR DESCRIPTION
6.7.0 was released 2.5 yrs ago, no need to mention. Also, not likely people reached this section if they didn't already have/know how to find the cf CLI?