### PR TITLE
Update documentation to include SOCKS5 proxy support

### DIFF
--- a/http-proxy.html.md.erb
+++ b/http-proxy.html.md.erb
@@ -1,11 +1,11 @@
 ---
-title: Using the cf CLI with an HTTP Proxy Server
+title: Using the cf CLI with a Proxy Server
 owner: CLI
 ---
 
 <strong><%= modified_date %></strong>
 
-If you have an HTTP proxy server on your network between a host running the cf CLI and your Cloud Foundry API endpoint, you must set `https_proxy` with the hostname or IP address of the proxy server.
+If you have an HTTP or SOCKS5 proxy server on your network between a host running the cf CLI and your Cloud Foundry API endpoint, you must set `https_proxy` with the hostname or IP address of the proxy server.
 
 The `https_proxy` environment variable holds the hostname or IP address of your
 proxy server.
@@ -25,6 +25,9 @@ If the proxy server requires a user name and password, include the credentials:
 If the proxy server uses a port other than 80, include the port number:
 `https_proxy=http://username:password@proxy.example.com:8080`
 
+If the proxy server is a SOCKS5 proxy, specify the SOCKS5 protocol in the URL: 
+`https_proxy=socks5://socks_proxy.example.com`
+*NOTE:`cf logs` and `cf ssh` do not work through a SOCKS5 proxy* 
 
 ## <a id="mac-linux"></a>Setting https_proxy in Mac OS or Linux ##
 


### PR DESCRIPTION
Golang 1.9 adds support for SOCKS5 proxies from the https_proxy environment variable. The cf CLI now supports SOCKS5 proxies as well (except for cf ssh and cf logs)

[#152946000]