### PR TITLE
use https for debian repo

### DIFF
--- a/install-go-cli.html.md.erb
+++ b/install-go-cli.html.md.erb
@@ -28,7 +28,7 @@ For Debian and Ubuntu-based Linux distributions, perform the following steps:
 
 1. Add the Cloud Foundry Foundation public key and package repository to your system:
 	<pre class="terminal">$ wget -q -O - https<span>:</span>//packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -</pre>
-	<pre class="terminal">$ echo "deb http<span>:</span>//packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list</pre>
+	<pre class="terminal">$ echo "deb https<span>:</span>//packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list</pre>
 1. Update your local package index:
 	<pre class="terminal">$ sudo apt-get update</pre>
 1. Install the cf CLI:


### PR DESCRIPTION
Use HTTPS to fix APT update bug. 

[#155275176] (cloudfoundry/cli#1327)