### PR TITLE
updated install-go-cli with an updated brew command for fetching cf-cli

### DIFF
--- a/install-go-cli.html.md.erb
+++ b/install-go-cli.html.md.erb
@@ -121,7 +121,7 @@ To install the cf CLI for Mac OS X using Homebrew, do the following:
 1. Install the cf CLI:
 
 	```
-	brew install cf-cli
+	brew install cloudfoundry/tap/cf-cli
 	```
 
 <% if not vars.product_name == 'CF' %>


### PR DESCRIPTION
I ran the original command and `brew install cf-cli` and got a message that the formulae did not exist. I got the updated command from `https://github.com/cloudfoundry/cli` and ran it. I updated that here.