### PR TITLE
added `map-route` to the table of changes

### DIFF
--- a/v7.html.md.erb
+++ b/v7.html.md.erb
@@ -236,6 +236,14 @@ The table below summarizes how commands differ between cf CLI v7 and cf CLI v6.
 	<td><em>This command is removed because the V1 Broker API is deprecated as of January 2015.</em></td>
 </tr>
 <tr>
+	<td><code>cf7 map-route</code></td>
+	<td>
+		<ul>
+			<li><strong>[Removed flag]:</strong> <code>--random-route</code> since it's now default if no <code>--port</code> is provided.</li>
+		</ul>
+	</td>
+</tr>
+<tr>
 	<td><code>cf7 marketplace</code></td>
 	<td>
 		<ul>


### PR DESCRIPTION
--random-route is now default in v7 so there's no need for the flag