### PR TITLE
Requirements for cf CLI v7

### DIFF
--- a/v7.html.md.erb
+++ b/v7.html.md.erb
@@ -41,6 +41,11 @@ Some key new features available through the cf CLI v7 are:
 
 To install cf CLI v7, see the [README](https://github.com/cloudfoundry/cli#downloads) in the Cloud Foundry CLI repository on GitHub. It includes instructions for downloading the latest CAPI release candidate, which is what the cf CLI v7 beta is tested against.
 
+### <a id="pre-requisites"></a> Pre-requisites
+
+V7 of the cf CLI requires [CF Deployment](https://github.com/cloudfoundry/cf-deployment) version v13.4.0 or later, which contains [CAPI release](https://github.com/cloudfoundry/capi-release) 1.95.0 (providing [v3 API](https://github.com/cloudfoundry/cloud_controller_ng) version 3.85.0).
+
+If targeting an older CF Deployment, the v7 cf CLI will present a warning saying that the API version is less than the minimum supported. Not all commands may run correctly; `cf apps`, for example, will not work.
 
 ## <a id="differences"></a> Command Differences
 


### PR DESCRIPTION
We are confident that the required version of CAPI (1.95.0) will be bundled in the next CF Deployment (v13.4.0 or v14.0.0).

Co-authored-by: Reid Mitchell <rmitchell@pivotal.io>