### PR TITLE
Requirements for cf CLI v7

### DIFF
--- a/v7.html.md.erb
+++ b/v7.html.md.erb
@@ -43,7 +43,7 @@ To install cf CLI v7, see the [README](https://github.com/cloudfoundry/cli#downl
 
 ### <a id="prerequisites"></a> Prerequisites
 
-The cf CLI v7 requires [cf-deployment](https://github.com/cloudfoundry/cf-deployment) v13.4.0 or later.
+The cf CLI v7 requires [cf-deployment](https://github.com/cloudfoundry/cf-deployment) v13.5.0 or later.
 
 This version of cf-deployment contains CAPI release v1.95.0, which provides the CAPI v3 API version 3.85.0.
 


### PR DESCRIPTION
We are confident that the required version of CAPI (1.95.0) will be bundled in the next CF Deployment (v13.5.0 or v14.0.0).

Version v13.4.0 did not bump the CAPI Release as we expected; instead, it only bumped the stemcell.