### PR TITLE
Document removal of service column from cf routes

### DIFF
--- a/v7.html.md.erb
+++ b/v7.html.md.erb
@@ -345,7 +345,7 @@ The table below summarizes how commands differ between cf CLI v7 and cf CLI v6.
 		<td style="vertical-align:top"><code>cf routes</code></td>
 		<td>
 			<ul>
-				<li><strong>[Updated output]:</strong> <code>port</code> and <code>type</code> no longer appear in the table.</li>
+				<li><strong>[Updated output]:</strong> <code>port</code>, <code>type</code>, and <code>service</code> no longer appear in the table. It is intended that <code>service</code> will be added again in a future version.</li>
 				<li><strong>[Renamed flag]:</strong> <code>--orglevel</code> is now <code>--org-level</code>.</li>
 			</ul>
 		</td>


### PR DESCRIPTION
This column was removed in cf v7 because the API to get routes service was not complete at the time