### PR TITLE
Update cf push output to include log rate details

### DIFF
--- a/getting-started.html.md.erb
+++ b/getting-started.html.md.erb
@@ -302,28 +302,29 @@ The example below pushes an app called `awesome-app` to the URL `http://awesome-
 
 <pre class="terminal">
 $ cf push awesome-app -b ruby_buildpack
-Creating app awesome-app in org example-org / space development as username@example.com...
-OK
+Pushing app awesome-app to org example-org / space development as username@example.com...
 
-Creating route awesome-app.example.com...
-OK
 ...
 
-1 of 1 instances running
+Waiting for app awesome-app to start...
 
-App started
-...
 
-requested state: started
-instances: 1/1
-usage: 1G x 1 instances
-urls: awesome-app.example.com
-last uploaded: Wed Jun 8 23:43:15 UTC 2016
-stack: cflinuxfs3
-buildpack: ruby_buildpack
+name:              awesome-app
+requested state:   started
+routes:            awesome-app.example.com
+last uploaded:     Fri 16 Sep 01:54:16 UTC 2022
+stack:             cflinuxfs3
+buildpacks:
+	name             version   detect output   buildpack name
+	ruby_buildpack   1.8.58    ruby            ruby
 
-     state     since                    cpu    memory    disk      details
-#0   running   2016-06-08 04:44:07 PM   0.0%   0 of 1G   0 of 1G
+type:            web
+sidecars:
+instances:       1/1
+memory usage:    1024M
+start command:   bundle exec rackup config.ru -p $PORT -o 0.0.0.0
+     state     since                  cpu    memory   disk     logging      details
+#0   running   2022-09-16T01:54:29Z   0.0%   0 of 0   0 of 0   0/s of 0/s
 </pre>
 
 ### <a id='new-route'></a> Map a Route to an App

--- a/getting-started.html.md.erb
+++ b/getting-started.html.md.erb
@@ -341,13 +341,15 @@ To map a route to the app:
     cf login
     ```
 
-1. Map a route by running:
+1. Push and map a route by running:
 
     ```
-    cf push APP-NAME --hostname APP-HOSTNAME
+    cf push APP-NAME
+    cf map-route APP-NAME APP-DOMAIN --hostname APP-HOSTNAME
     ```
     Where:
       * `APP-NAME` is the name of the app.
+      * `APP-DOMAIN` is the domain of the app.
       * `APP-HOSTNAME` is the hostname of the app.
 
 

--- a/getting-started.html.md.erb
+++ b/getting-started.html.md.erb
@@ -370,7 +370,7 @@ You can provide these parameters in these ways:
 * Non-interactively. For more information, see [Supply Parameters Non-Interactively](#non-interactive).
 
 * With third-party log management software as described in RFC 6587. For more information, see [Supply Parameters Through a Third Party](#third-party) and [RFC 6587](http://tools.ietf.org/html/rfc6587).
-    <p class="note"><strong>Note:</strong> When used with third-party logging, the cf CLI sends data formatted according to RFC 5424. For more information, see [RFC 5424](http://tools.ietf.org/html/rfc5424).</p>
+    <p class="note"><strong>Note:</strong> When used with third-party logging, data is sent formatted according to RFC 5424. For more information, see [RFC 5424](http://tools.ietf.org/html/rfc5424).</p>
 
 #### <a id='interactive'></a> Supply Parameters Interactively
 


### PR DESCRIPTION
* The cf CLI now supports reporting the logging rate of an application. Update the `cf push` output to show this.
* The `--hostname` flag is no longer accepted by `cf push`. Describe use of `cf map-route` to add the route. An alternative would be to define the route in the manifest file.
* The existing wording implied that the cf CLI itself was sending syslog messages. This is not correct.