### PR TITLE
Update CAPI v2 docs links to new subdomain

### DIFF
--- a/getting-started.html.md.erb
+++ b/getting-started.html.md.erb
@@ -273,7 +273,7 @@ either `cf set-org-role` or `cf unset-org-role` returns an error similar to the 
 <pre class="terminal">The user exists in multiple origins. Specify an origin for the requested user from: ‘uaa’, ‘other’</pre>
 
 To resolve this ambiguity, you can construct a `curl` command that uses the API to perform the desired role management function. For an example, see the
-[Cloud Foundry API documentation](http://apidocs.cloudfoundry.org/280/organizations/associate_auditor_with_the_organization_by_username.html).
+[Cloud Foundry API documentation](https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#create-a-role).
 
 
 ## <a id='push'></a> Push an app

--- a/v7.html.md.erb
+++ b/v7.html.md.erb
@@ -14,7 +14,7 @@ The cf CLI development team aims to provide:
 
 To understand the differences between specific commands, see [Command Differences](#differences) below.
 
-For more information about CAPI V3, see the [CAPI V3 documentation](https://v3-apidocs.cloudfoundry.org/index.html#introduction). For more information about CAPI V2, see the [CAPI V2 documentation](http://apidocs.cloudfoundry.org/).
+For more information about CAPI V3, see the [CAPI V3 documentation](https://v3-apidocs.cloudfoundry.org/index.html#introduction). For more information about CAPI V2, see the [CAPI V2 documentation](http://v2-apidocs.cloudfoundry.org/).
 
 ## <a id="new-workflows"></a> New workflows supported by cf CLI v7
 


### PR DESCRIPTION
This PR updates CAPI v2 docs links from `apidocs.cloudfoundry.org` to `v2-apidocs.cloudfoundry.org`.
The goal is to signal that v3 is the primary API, also a necessary step in eventually sunsetting v2.

~~The infrastructure hosting the app serving docs at apidocs.cloudfoundry.org is expected to go down imminently, so this change is needed to avoid dead links.~~
`apidocs.cloudfoundry.org` has been converted to a redirect to `v3-apidocs.cloudfoundry.org`, so this change is needed to avoid incorrect links

See capi-release PRs [#440](https://github.com/cloudfoundry/capi-release/pull/440) and [#441](https://github.com/cloudfoundry/capi-release/pull/441)