### PR TITLE
update ubuntu install steps

### DIFF
--- a/install-go-cli.html.md.erb
+++ b/install-go-cli.html.md.erb
@@ -39,8 +39,8 @@ To install the cf CLI on Debian and Ubuntu-based Linux distributions:
 
 1. Add the Cloud Foundry Foundation public key and package repository to your system by running:
 
-		wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
-		echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+		sudo wget -q -O /usr/share/keyrings/cli.cloudfoundry.org.gpg https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key
+		echo "deb [signed-by=/usr/share/keyrings/cli.cloudfoundry.org.key] https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
 
 1. Update your local package index by running:
 


### PR DESCRIPTION
`apt-key` is deprecated since quite a while in Debian/Ubuntu.
This PR updates the repo add steps for Ubuntu/Debian.
They are supported with Debian 9+ and Ubuntu 18.04+.

I also created an issue to update the cli wiki page: https://github.com/cloudfoundry/cli/issues/3210
