### PR TITLE
fix ubuntu cli install steps

### DIFF
--- a/install-go-cli.html.md.erb
+++ b/install-go-cli.html.md.erb
@@ -39,8 +39,8 @@ To install the cf CLI on Debian and Ubuntu-based Linux distributions:
 
 1. Add the Cloud Foundry Foundation public key and package repository to your system by running:
 
-		sudo wget -q -O /usr/share/keyrings/cli.cloudfoundry.org.gpg https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key
-		echo "deb [signed-by=/usr/share/keyrings/cli.cloudfoundry.org.key] https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+		wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo gpg --dearmor -o /usr/share/keyrings/cli.cloudfoundry.org.gpg
+		echo "deb [signed-by=/usr/share/keyrings/cli.cloudfoundry.org.gpg] https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
 
 1. Update your local package index by running:
 


### PR DESCRIPTION
@pspinrad I did screw up copying the right commands from my test system. Sorry!
Due the combination of two mistakes, it was still working for me.

The downloaded key first needs to be converted into the gpg format and then the correct file needs to be referenced.

I also updated: https://github.com/cloudfoundry/cli/issues/3210