### PR TITLE
Extract user role management from getting-started

### DIFF
--- a/getting-started.html.md.erb
+++ b/getting-started.html.md.erb
@@ -111,115 +111,20 @@ By default, `config.json` is located in the `~/.cf` directory. You can relocate 
 
 ## <a id='user-roles'></a> Manage users and roles
 
-The cf CLI includes commands that list users and assign roles in orgs and spaces.
+The cf CLI includes commands to list users and assign roles in orgs and spaces. For a full reference, including role assignment for UAA clients and multi-origin disambiguation, see [Managing roles](../concepts/managing-roles.html).
 
-### <a id='listing-users'></a> List users
+For more information about the available roles and their permissions, see [Orgs, Spaces, Roles, and Permissions](../concepts/roles.html).
 
-To list all users in an org or a space:
-
-1. In a terminal window, log in to the cf CLI:
-
-    ```
-    cf login
-    ```
-
-1. Run one of these commands:
-    * To list org users, run:
-
-        ```
-        cf org-users ORG
-        ```
-        Where `ORG` is the name of the org for which you want to see the list of users.
-        <br>
-        <br>
-        The above command returns output similar to the example below:
-        <pre class="terminal">
-        Getting users in org example-org as username<span>@</span>example.com...
-
-        ORG MANAGER
-          username<span>@</span>example.com
-
-        BILLING MANAGER
-          huey<span>@</span>example.com
-          dewey<span>@</span>example.com
-
-        ORG AUDITOR
-          louie<span>@</span>example.com
-        </pre>
-    * To list space users, run:
-
-        ```
-        cf space-users ORG SPACE
-        ```
-        Where:
-        <ul>
-          <li><code>ORG</code> is the name of the org that contains the space for which you want to see the list of users.</li>
-          <li><code>SPACE</code> is the name of the space for which you want to see the list of users.</li>
-        </ul>
-
-        The above command returns output similar to the example below:
-        <pre class="terminal">
-        Getting users in org example-org / space example-space as username<span>@</span>example.com...
-
-        SPACE MANAGER
-          username<span>@</span>example.com
-
-        SPACE DEVELOPER
-          huey<span>@</span>example.com
-          dewey<span>@</span>example.com
-
-        SPACE AUDITOR
-          louie<span>@</span>example.com
-        </pre>
-
-For more information about the `cf org-users` command, use `cf org-users --help`. For
-more information about the `cf space-users` command, use `cf space-users --help`.
-
-### <a id='managing-roles'></a> Manage roles
-
-You use the commands listed below to manage roles in the cf CLI. These commands require admin permissions and take `username`, `org` or `space`, and `role` as
-arguments:
-
-* `cf set-org-role`<br>For more information, use `cf set-org-role --help`.
-
-* `cf unset-org-role`<br>For more information, use `cf unset-org-role --help`.
-
-* `cf set-space-role`<br>For more information, use `cf set-space-role --help`.
-
-* `cf unset-space-role`<br>For more information, use `cf unset-space-role --help`.
-
-The available roles are:
-
-* `OrgManager`
-* `BillingManager`
-* `OrgAuditor`
-* `SpaceManager`
-* `SpaceDeveloper`
-* `SpaceAuditor`
-
-For more information about user roles, see [Orgs, Spaces, Roles, and Permissions](../concepts/roles.html).
-
-The following example shows the terminal output for `cf set-org-role huey@example.com example-org OrgManager`, which assigns the Org Manager role to
-`huey@example.com` within the `example-org` org:
+The following example assigns the Org Manager role to `huey@example.com` in `example-org`:
 
 <pre class="terminal">
+$ cf set-org-role huey<span>@</span>example.com example-org OrgManager
 Assigning role OrgManager to user huey<span>@</span>example.com in org example-org as username<span>@</span>example.com...
 OK
 </pre>
 
 <p class="note important">
-If you are not an admin, you see this message when you try to run these commands: <code>error code: 10003, message: You
-are not authorized to perform the requested action</code></p>
-
-### <a id='multi-origin'></a> Manage roles for users with identical usernames in multiple origins
-
-If a username corresponds to multiple accounts from different user stores, such as both the internal UAA store and an external SAML or LDAP store, running
-either `cf set-org-role` or `cf unset-org-role` returns an error similar to the following example:
-
-<pre class="terminal">The user exists in multiple origins. Specify an origin for the requested user from: ‘uaa’, ‘other’</pre>
-
-To resolve this ambiguity, you can construct a `curl` command that uses the API to perform the desired role management function. For an example, see the
-[Cloud Foundry API documentation](https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#create-a-role).
+If you are not an admin, you see this message when you try to run these commands: <code>error code: 10003, message: You are not authorized to perform the requested action</code></p>
 
 
 ## <a id='push'></a> Push an app


### PR DESCRIPTION
- Replaced by new, comprehensive documentation in cloudfoundry/docs-cloudfoundry-concepts (https://github.com/cloudfoundry/docs-cloudfoundry-concepts/pull/214)
- Add links to additional documentation on CF roles, permissions, and user management

[Content partially generated via Claude Sonnet 4.6]