### PR TITLE
Docs: document cf route-policy commands for identity-aware routing (RFC-0055)

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -14,3 +14,7 @@ These topics explain the Cloud Foundry Command Line Interface (cf CLI), a tool u
 * [Using the cf CLI with a self-signed certificate](self-signed.html)
 * [Using cf CLI plug-ins](use-cli-plugins.html)
 * [Developing cf CLI plug-ins](develop-cli-plugins.html)
+
+## New in cf CLI v8: Route policy commands
+
+cf CLI v8 includes commands for managing route policies for identity-aware routing: `cf add-route-policy`, `cf route-policies`, and `cf remove-route-policy`. For more information, see [Upgrading to cf CLI v8](v8.html) and [Configuring identity-aware routing](../devguide/deploy-apps/identity-aware-routing.html).

--- a/v8.html.md.erb
+++ b/v8.html.md.erb
@@ -24,6 +24,13 @@ Some key new features available through the cf CLI v8 are:
 
 * **Asynchronous service operations**: All service-related operations are now asynchronous by default. This includes manipulating service keys and route bindings.
 
+* **Identity-aware routing (route policies)**: cf CLI v8 includes commands for managing route policies used with identity-aware domains. These commands allow Space Developers to control which apps can reach a route on an identity-aware (mTLS) domain:
+  * `cf add-route-policy` — Add a policy allowing a named caller to reach a route.
+  * `cf route-policies` — List policies for routes on a domain, with optional filters.
+  * `cf remove-route-policy` — Remove a policy from a route.
+
+  For full usage and examples, see [Configuring identity-aware routing](../devguide/deploy-apps/identity-aware-routing.html).
+
 
 ## <a id="install"></a> Install cf CLI v8
 


### PR DESCRIPTION
## Summary

Documents the three new cf CLI v8 commands for identity-aware routing:

- `v8.html.md.erb`: adds an Identity-aware routing entry in the New workflows section with `cf add-route-policy`, `cf route-policies`, `cf remove-route-policy` and a link to the full developer how-to
- `index.html.md.erb`: adds a brief note at the bottom pointing readers to the new route-policy commands

## References

- RFC-0055: https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0055-identity-aware-routing-for-gorouter.md
- Developer how-to PR: cloudfoundry/docs-dev-guide#594